### PR TITLE
rubocop のWarningを修正

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -3,13 +3,13 @@ inherit_from: .rubocop_todo.yml
 Style/AsciiComments:
   Enabled: false
 
-Style/ClassLength:
+Metrics/ClassLength:
   Max: 200
 
 Style/IfUnlessModifier:
   Enabled: false
 
-Style/MethodLength:
+Metrics/MethodLength:
   Max: 50
 
 Style/PercentLiteralDelimiters:
@@ -18,8 +18,8 @@ Style/PercentLiteralDelimiters:
 Style/RedundantReturn:
   Enabled: false
 
-Style/RegexpLiteral:
-  MaxSlashes: 0
+#Style/RegexpLiteral:
+#  MaxSlashes: 2
 
 Style/SpecialGlobalVars:
   Enabled: false


### PR DESCRIPTION
rubocop.yml でWarningが出ているので、修正しました。
Style ではなく Metrics を使えという修正が2つ、MaxSlashes は調べても正しい書き方がよくわからないので削除してしまいました。
rubocop のバージョンは 0.41.2 です。そちらの環境では Warning が出ていないという場合は教えて下さい。