### PR TITLE
開発環境ではメール送信の代わりにブラウザで閲覧できるように

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -1,5 +1,6 @@
 FACEBOOK_APP_ID=12341234
 FACEBOOK_APP_SECRET="hogehogehoge"
+DELIVERY_METHOD=smtp
 SMTP_SERVER='smtp.gmail.com'
 SMTP_PORT=587
 SMTP_DOMAIN='googleapps.domain'

--- a/Gemfile
+++ b/Gemfile
@@ -47,6 +47,11 @@ group :development, :test do
   gem 'rails-erd'
 end
 
+group :development do
+  gem 'letter_opener'
+  gem 'letter_opener_web'
+end
+
 group :production do
   # gem 'pg'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -45,6 +45,8 @@ GEM
       minitest (~> 5.1)
       thread_safe (~> 0.3, >= 0.3.4)
       tzinfo (~> 1.1)
+    addressable (2.5.0)
+      public_suffix (~> 2.0, >= 2.0.2)
     arel (6.0.3)
     autoprefixer-rails (6.5.3)
       execjs
@@ -102,6 +104,14 @@ GEM
       thor (>= 0.14, < 2.0)
     json (1.8.3)
     jwt (1.5.6)
+    launchy (2.4.3)
+      addressable (~> 2.3)
+    letter_opener (1.4.1)
+      launchy (~> 2.2)
+    letter_opener_web (1.3.0)
+      actionmailer (>= 3.2)
+      letter_opener (~> 1.0)
+      railties (>= 3.2)
     loofah (2.0.3)
       nokogiri (>= 1.5.9)
     mail (2.6.4)
@@ -147,6 +157,7 @@ GEM
     pry-stack_explorer (0.4.9.2)
       binding_of_caller (>= 0.7)
       pry (>= 0.9.11)
+    public_suffix (2.0.4)
     rack (1.6.5)
     rack-test (0.6.3)
       rack (>= 1.0)
@@ -236,6 +247,8 @@ DEPENDENCIES
   google-analytics-rails
   jbuilder (~> 2.0)
   jquery-rails
+  letter_opener
+  letter_opener_web
   mysql2 (~> 0.3.20)
   omniauth-facebook
   pry-byebug

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -15,7 +15,7 @@ Rails.application.configure do
 
   # Don't care if the mailer can't send.
   config.action_mailer.raise_delivery_errors = true
-  config.action_mailer.delivery_method = :smtp
+  config.action_mailer.delivery_method = ENV['DELIVERY_METHOD'] ? ENV['DELIVERY_METHOD'].to_sym : :letter_opener_web
   config.action_mailer.smtp_settings = {
     address:               Rails.application.secrets.smtp_address,
     port:                  Rails.application.secrets.smtp_port,
@@ -25,7 +25,6 @@ Rails.application.configure do
     authentication:        'plain',
     enable_starttls_auto:  true
   }
-
   config.action_mailer.default_url_options = {
     host: ENV['APP_HOST'] || 'localhost:3000'
   }

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -51,6 +51,8 @@ Rails.application.routes.draw do
   resources :projects
   resources :users
 
+  mount LetterOpenerWeb::Engine, at: "/letter_opener" if Rails.env.development?
+
   # The priority is based upon order of creation: first created -> highest priority.
   # See how all your routes lay out with "rake routes".
 


### PR DESCRIPTION
https://github.com/codeforkanazawa-org/ha4go/issues/170 に対応しています。

開発環境ではメールを送信する代わりにブラウザで閲覧できるようになります。

この変更で、メールサーバを用意することなく  `http://localhost:3000/letter_opener`で メールの内容を確認することが可能です。

## スクリーンショット

![image](https://cloud.githubusercontent.com/assets/758704/20863234/8e454d12-ba07-11e6-8157-c0cf32c17400.png)
