### PR TITLE
ログインユーザのアイコンをヘッダに表示

### DIFF
--- a/app/assets/stylesheets/matsu/style.scss
+++ b/app/assets/stylesheets/matsu/style.scss
@@ -91,12 +91,6 @@ a {
   padding-top: 5px;
 }
 
-/*ログイン後表示する*/
-
-.login_after, .user_name {
-  display: none;
-}
-
 .header_nav {
   list-style: none;
 }


### PR DESCRIPTION
https://github.com/codeforkanazawa-org/ha4go/issues/66 に対応しています。


## スクリーンショット

![image](https://cloud.githubusercontent.com/assets/758704/20865910/2ef5fc52-ba62-11e6-8b39-8982e934fbb0.png)
