### PR TITLE
URLや開発用URLが存在しない場合はURLがないことを表示

### DIFF
--- a/app/views/projects/show.html.erb
+++ b/app/views/projects/show.html.erb
@@ -45,13 +45,21 @@
     <!-- URL -->
     <div class="content_development_url clearfix">
       <div class="content_development_url_left"><%= t('dic.url')  %></div>
-      <div class="content_development_url_right"><%= link_to @project.user_url, @project.user_url %></div>
+      <div class="content_development_url_right">
+        <%= link_to_if @project.user_url, @project.user_url, @project.user_url  do %>
+          <span><%= t('dic.url') %>はありません</span>
+        <% end %>
+      </div>
     </div>
 
     <!-- 開発URL -->
     <div class="content_development_url clearfix">
       <div class="content_development_url_left"><%= t('dic.dev_url')  %></div>
-      <div class="content_development_url_right"><%= link_to @project.development_url, @project.development_url %></div>
+      <div class="content_development_url_right">
+        <%= link_to_if @project.development_url, @project.development_url, @project.development_url do %>
+          <span><%= t('dic.dev_url') %>はありません</span>
+        <% end %>
+       </div>
     </div>
 
     <!-- ステータス -->

--- a/app/views/shared/_project.html.erb
+++ b/app/views/shared/_project.html.erb
@@ -24,13 +24,21 @@
   <!-- URL -->
   <div class="content_development_url clearfix">
     <div class="content_development_url_left"><%= t('dic.url')  %></div>
-    <div class="content_development_url_right"><%= link_to project.user_url, project.user_url %></div>
+    <div class="content_development_url_right">
+      <%= link_to_if project.user_url, project.user_url, project.user_url do %>
+        <span><%= t('dic.url') %>はありません</span>
+      <% end %>
+    </div>
   </div>
 
   <!-- 開発URL -->
   <div class="content_development_url clearfix">
     <div class="content_development_url_left"><%= t('dic.dev_url')  %></div>
-    <div class="content_development_url_right"><%= link_to project.development_url, project.development_url %></div>
+    <div class="content_development_url_right">
+      <%= link_to_if project.development_url,  project.development_url, project.development_url do %>
+        <span><%= t('dic.dev_url') %>はありません</span>
+      <% end %>
+    </div>
   </div>
 
   <!-- ステータス -->


### PR DESCRIPTION
`link_to` の引数に nil が入ると表示しているリンクのパスが表示されてしまうので、プロジェクトのURL、開発URLが存在しない場合はその旨をテキストで表示するようにしました。

URL、もしくは開発URLが存在しないプロジェクトを作成すると再現します。

## 修正前

![image](https://user-images.githubusercontent.com/758704/34648937-c5f06ac4-f3e7-11e7-954d-341970a4dd28.png)


## 修正後

![image](https://user-images.githubusercontent.com/758704/34648924-7fa7f69a-f3e7-11e7-85db-57680c07ac02.png)
