### PR TITLE
送信するメールアドレスの指定方法を修正

### DIFF
--- a/app/mailers/project_mailer.rb
+++ b/app/mailers/project_mailer.rb
@@ -1,7 +1,7 @@
 # coding: utf-8
 class ProjectMailer < ApplicationMailer
   add_template_helper(ApplicationHelper)
-  default from: "ha4go@#{ENV.fetch('APP_HOST') { 'codeforkanazawa.org' }}"
+  default from: ENV['NOTIF_MAIL_FROM'] || ENV['SMTP_USER'] || "ha4go@#{ENV.fetch('APP_HOST') { 'codeforkanazawa.org' }}"
 
   def tell_create(mails, project)
     @project = project


### PR DESCRIPTION
https://github.com/codeforkanazawa-org/ha4go/pull/217#discussion_r169740271 の

> `ENV['NOTIF_MAIL_FROM '] || ENV['SMTP_USER'] || ha4go@#{ENV.fetch('APP_HOST') { 'codeforkanazawa.org' }`
> 
> あたりにしておいてほしいです。

の対応になります。