### PR TITLE
Feature/fix dockerfiles

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -13,3 +13,5 @@ mysql/*
 GTAGS
 GRTAGS
 GPATH
+
+log

--- a/Dockerfile.base
+++ b/Dockerfile.base
@@ -1,4 +1,4 @@
-FROM ubuntu:14.04
+FROM ubuntu:18.04
 
 ENV DEBIAN_FRONTEND noninteractive
 
@@ -15,14 +15,14 @@ RUN apt-get update && \
     libxslt1-dev \
     libyaml-dev \
     zlib1g-dev && \
-    curl -O http://ftp.ruby-lang.org/pub/ruby/2.3/ruby-2.3.3.tar.gz && \
-    tar -zxvf ruby-2.3.3.tar.gz && \
-    cd ruby-2.3.3 && \
+    curl -O http://ftp.ruby-lang.org/pub/ruby/2.6/ruby-2.6.2.tar.gz && \
+    tar -zxvf ruby-2.6.2.tar.gz && \
+    cd ruby-2.6.2 && \
     ./configure --disable-install-doc && \
     make && \
     make install && \
     cd .. && \
-    rm -r ruby-2.3.3 ruby-2.3.3.tar.gz && \
+    rm -r ruby-2.6.2 ruby-2.6.2.tar.gz && \
     echo 'gem: --no-document' > /usr/local/etc/gemrc
 
 # Install Bundler for each version of ruby
@@ -37,9 +37,5 @@ RUN apt-get install -y libmysqld-dev libpq-dev
 
 # Install Node.js and npm
 RUN \
-  apt-get install -y software-properties-common && \
-  apt-get update && \
-  add-apt-repository -y ppa:chris-lea/node.js && \
-  echo "deb http://archive.ubuntu.com/ubuntu precise universe" >> /etc/apt/sources.list && \
   apt-get update && \
   apt-get install -y nodejs

--- a/Dockerfile.front
+++ b/Dockerfile.front
@@ -15,5 +15,5 @@ ADD . /myapp/
 ENV RAILS_ENV  production
 
 EXPOSE 3000
-# CMD ["bundle exec rails s"]
-CMD bash -l -c 'bundle exec rails s --bind=0.0.0.0'
+
+CMD bash -l -c 'bundle exec rake assets:precompile && bundle exec rails s'

--- a/Dockerfile.front
+++ b/Dockerfile.front
@@ -3,7 +3,7 @@ FROM ha4go-base:1.0
 RUN mkdir /myapp
 WORKDIR /myapp
 
-RUN apt-get install -y libmagickwand-dev
+RUN apt-get install -y libmagickwand-dev tzdata
 
 ADD Gemfile Gemfile
 ADD Gemfile.lock Gemfile.lock
@@ -13,18 +13,6 @@ ADD . /myapp/
 
 # ADD .env /myapp/.env
 ENV RAILS_ENV  production
-ENV MYSQL_HOST 192.168.3.1
-ENV MYSQL_USER ha4go
-ENV MYSQL_PW ha4goha4go
-ENV DATABASE_NAME ha4go
-RUN bundle exec rake db:create
-RUN bundle exec rake db:migrate
-RUN bundle exec rake db:seed
-RUN bundle exec rake assets:precompile
-
-# Add configuration files in repository to filesystem
-# ADD start-server.sh /usr/bin/start-server
-# RUN chmod +x /usr/bin/start-server
 
 EXPOSE 3000
 # CMD ["bundle exec rails s"]

--- a/Rakefile.deploy
+++ b/Rakefile.deploy
@@ -1,3 +1,7 @@
+require 'dotenv'
+
+Dotenv.load
+
 SUDO = ENV['SUDO'] || ''
 NOCACHE = ENV['NOCACHE'] || ''
 
@@ -79,9 +83,21 @@ task :run, [:role, :local, :docker_ip] do |_t, a|
   e = a[:local] || 'DEBUG'
   sh Cmd.gen([
                DOCKER,
-               'run',
+               "run --name #{NAMES[r]}",
                "#{DOCKER_OPTIONS[e][r]}",
                "#{NAMES[r]}:#{TAGS[r]}",
                "#{DOCKER_COMMAND[e][r]}"
+             ])
+end
+
+desc 'console[<role>,<base>,<`docker-machine ip default`>]'
+task :console, [:role, :local, :docker_ip] do |_t, a|
+  r = a[:role]
+  e = a[:local] || 'DEBUG'
+  sh Cmd.gen([
+               DOCKER,
+               "exec -it #{NAMES[r]}",
+               "#{NAMES[r]}:#{TAGS[r]}",
+               'bash'
              ])
 end

--- a/Rakefile.deploy
+++ b/Rakefile.deploy
@@ -97,7 +97,6 @@ task :console, [:role, :local, :docker_ip] do |_t, a|
   sh Cmd.gen([
                DOCKER,
                "exec -it #{NAMES[r]}",
-               "#{NAMES[r]}:#{TAGS[r]}",
                'bash'
              ])
 end


### PR DESCRIPTION
Dockerfileのベースイメージを18.04に変更
Ruby 2.6を採用
ビルド時にDBのマイグレートやアセットコンパイルを行っていたがそれは開始時にやることにする
デプロイ用スクリプトを修正