### PR TITLE
Web用のDocker base imageをRuby 2.6.2に更新

### DIFF
--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -1,4 +1,4 @@
-FROM ruby:2.3.1
+FROM ruby:2.6.2
 RUN apt-get update -qq && apt-get install -y build-essential libpq-dev nodejs
 RUN mkdir /myapp
 WORKDIR /myapp


### PR DESCRIPTION
docker-compose を使って開発環境環境を立ち上げようとしたときに、Dockerfile.devのRubyバージョンが古いものになっていたので更新。

(別でMySQLに接続できない問題が手元で起きているが、別途調査してPR上げようと思います)